### PR TITLE
Add breadcrumbs to search results

### DIFF
--- a/extension/figma-bridge.js
+++ b/extension/figma-bridge.js
@@ -20,7 +20,7 @@
 
   function processSearch({ searchString }) {
     const searchResult = figma.root
-      .findAll(item => item.name.toLocaleLowerCase().includes(searchString))
+      .findAll(item => item.name.toLocaleLowerCase().includes(searchString) && item.type !== 'DOCUMENT')
       .map(({ id, name, type }) => {
         return {
           id,

--- a/extension/figma-bridge.js
+++ b/extension/figma-bridge.js
@@ -21,12 +21,17 @@
   function processSearch({ searchString }) {
     const searchResult = figma.root
       .findAll(item => item.name.toLocaleLowerCase().includes(searchString) && item.type !== 'DOCUMENT')
-      .map(({ id, name, type }) => {
+      .map(item => {
+        const { id, name, type } = item;
+        const { pageTitle, frameTitle } = findRootParentTitles(item);
+
         return {
           id,
           name,
           loweredName: name.toLocaleLowerCase(),
           type: type.toLocaleLowerCase().replace(/_/g, '-'),
+          pageTitle,
+          frameTitle,
         }
       });
 
@@ -121,6 +126,28 @@
 
       setTimeout(waitAndLoadNextPage.bind(null, alreadyWaitedMS + 100), 100);
     }
+  }
+
+  function findRootParentTitles(node) {
+    let pageNode = node;
+    let frameNode = node;
+
+    while (pageNode.type !== 'PAGE') {
+      frameNode = pageNode;
+      pageNode = pageNode.parent;
+    }
+
+    const result = {};
+
+    if (pageNode === node) return result;
+
+    result.pageTitle = pageNode.name;
+
+    if (frameNode.type === 'FRAME' && frameNode !== node) {
+      result.frameTitle = frameNode.name;
+    }
+
+    return result;
   }
 
   function sendMessage(message) {

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -390,8 +390,17 @@ button[disabled], input[disabled] {
   min-height: 40px;
   padding: 8px 16px 8px 48px;
   text-align: left;
+}
+
+.list__item-title {
   font-size: 13px;
   line-height: 16px;
+}
+
+.list__item-subtitle {
+  font-size: 10px;
+  line-height: 12px;
+  color: #737388;
 }
 
 .list__empty-notice {

--- a/extension/popup/list.js
+++ b/extension/popup/list.js
@@ -106,7 +106,25 @@ class List {
 
     if (items.length) {
       const listItems = items.map(i => {
-        return `<li><button class="list__item list__item_type_${i.type}" type="button" data-id="${i.id}">${i.name}</button></li>`
+        let subtitle = '';
+
+        if (i.pageTitle) {
+          subtitle += i.pageTitle;
+        }
+
+        if (i.frameTitle) {
+          subtitle += `&nbsp;→ ${i.frameTitle}`;
+        }
+
+        return `
+          <li>
+            <button class="list__item list__item_type_${i.type}" type="button" data-id="${i.id}">
+              <span class="list__item-title">${i.name}</span>
+              ${subtitle ? '<br/>' : ''}
+              ${subtitle ? `<span class="list__item-subtitle">${subtitle}</span>` : ''}
+            </button>
+          </li>
+        `;
       }).join('');
 
       list = `<ul class="list__items">${listItems}</ul>`;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tasks/build.sh",
     "generate-icon-styles": "tasks/generate-icon-styles.js",
     "serv": "node test/server.js",
-    "start": "nodemon --signal SIGUSR1 --exec 'npm run test' -w test/",
+    "start": "nodemon --signal SIGUSR1 --exec 'npm run test' -w test/ -w extension/",
     "test": "mocha --timeout 10000 --retries 3 test/test.js"
   },
   "devDependencies": {

--- a/test/server.js
+++ b/test/server.js
@@ -18,6 +18,7 @@ const startServer = () => new Promise(resolve => {
   process.on('exit', () => server.close());
 
   server.listen(8080, () => resolve(server));
+  console.log('http://localhost:8080');
 })
 
 if (module === require.main) {

--- a/test/server.js
+++ b/test/server.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const http = require('http');
 
-const startServer = () => new Promise(resolve => {
+const startServer = (port = 8080) => new Promise(resolve => {
   let server = http.createServer((req, res) => {
     fs.readFile(path.resolve(__dirname, '..', `./${req.url}`), (err, data) => {
       if (err) {
@@ -17,8 +17,8 @@ const startServer = () => new Promise(resolve => {
 
   process.on('exit', () => server.close());
 
-  server.listen(8080, () => resolve(server));
-  console.log('http://localhost:8080');
+  server.listen(port, () => resolve(server));
+  console.log(`Starting server on http://localhost:${port}\n`);
 })
 
 if (module === require.main) {

--- a/test/test.js
+++ b/test/test.js
@@ -343,6 +343,51 @@ describe('List', function() {
 
     await popup.waitForSelector('.list__item_selected', { visible: true });
   });
+
+  it('should show root page & root frame name as subtitle when they exist', async () => {
+    const popup = await openPopup();
+
+    await popup.focus('#input');
+    await page.keyboard.type('widget');
+
+    await popup.waitForSelector('.list', { visible: true });
+
+    const itemTitle = (await popup.evaluate(`document.querySelector('.list:nth-child(2) .list__item-title').textContent`)).trim();
+    const itemSubtitle = (await popup.evaluate(`document.querySelector('.list:nth-child(2) .list__item-subtitle').textContent`)).trim();
+
+    expect(itemTitle).eql('Widgets');
+    expect(itemSubtitle).eql('iOS\xa0→ Widgets');
+  });
+
+  it('should show only root page name as subtitle when root frame does not exist', async () => {
+    const popup = await openPopup();
+
+    await popup.focus('#input');
+    await page.keyboard.type('widget');
+
+    await popup.waitForSelector('.list', { visible: true });
+
+    const itemTitle = (await popup.evaluate(`document.querySelector('.list:nth-child(1) .list__item-title').textContent`)).trim();
+    const itemSubtitle = (await popup.evaluate(`document.querySelector('.list:nth-child(1) .list__item-subtitle').textContent`)).trim();
+
+    expect(itemTitle).eql('Widgets');
+    expect(itemSubtitle).eql('iOS');
+  });
+
+  it('should not show root page names for pages', async () => {
+    const popup = await openPopup();
+
+    await popup.focus('#input');
+    await page.keyboard.type('ios');
+
+    await popup.waitForSelector('.list', { visible: true });
+
+    const itemTitle = (await popup.evaluate(`document.querySelector('.list:nth-child(1) .list__item-title').textContent`)).trim();
+    const itemSubtitle = await popup.evaluate(`document.querySelector('.list:nth-child(1) .list__item-subtitle')`);
+
+    expect(itemTitle).eql('iOS');
+    expect(itemSubtitle).eql(null);
+  });
 });
 
 describe('Empty Notices', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -84,6 +84,21 @@ describe('Preloader', function() {
 });
 
 describe('Filter', function() {
+  it('should not show DOCUMENT node in results', async () => {
+    const popup = await openPopup();
+
+    await popup.focus('#input');
+    await page.keyboard.type('ios');
+
+    await popup.waitForSelector('.list', { visible: true });
+
+    const documentNodesCount = await popup.evaluate(() => {
+      return [...document.querySelectorAll('.list__item-title')].filter(x => x.textContent === '(Variants) iOS & iPadOS 14 UI Kit for Figma (Community)').length;
+    });
+
+    expect(documentNodesCount).eql(0);
+  });
+
   it('should show groups filter', async () => {
     const popup = await openPopup();
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ const puppeteer = require('puppeteer');
 const { expect } = require('chai');
 
 const startServer = require('./server');
+const SERVER_PORT = 8081;
 
 let browser, page, server;
 
@@ -14,7 +15,7 @@ process.on('exit', () => {
 });
 
 before(async function() {
-  server = await startServer();
+  server = await startServer(SERVER_PORT);
   browser = await puppeteer.launch();
 });
 
@@ -40,7 +41,7 @@ beforeEach(async function() {
     height: 800,
   });
 
-  await page.goto('http://localhost:8080/test/index.html');
+  await page.goto(`http://localhost:${SERVER_PORT}/test/index.html`);
 });
 
 afterEach(async function() {


### PR DESCRIPTION
This PR adds breadcrumbs: item's root page & root frame names that are shown as subtitles. Demo:

![localhost_8080_test_index html (2)](https://user-images.githubusercontent.com/6537798/115896253-e542a600-a463-11eb-9e26-cd49a87883c5.png)

Related to #1